### PR TITLE
typo "valute"

### DIFF
--- a/doc_source/CHAP_Tasks.CustomizingTasks.TableMapping.md
+++ b/doc_source/CHAP_Tasks.CustomizingTasks.TableMapping.md
@@ -110,6 +110,8 @@ For table mapping rules that use the transformation rule type, the following val
 
 [\[See the AWS documentation website for more details\]](http://docs.aws.amazon.com/dms/latest/userguide/CHAP_Tasks.CustomizingTasks.TableMapping.html)
 
+"valute" => "value"
+
 **Example Rename a Schema**  
 The following example renames a schema from **Test** in your source to **Test1** in your target endpoint:  
 


### PR DESCRIPTION
In the table that is not is not included here, the "Description" column of the "rule-type" parameter row misspells "value" as "valute".

*Issue #, if available:*

*Description of changes:*

fix spelling

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
