### PR TITLE
Missing a comma in the NUMERIC type example

### DIFF
--- a/doc_source/CHAP_Source.S3.md
+++ b/doc_source/CHAP_Source.S3.md
@@ -116,7 +116,7 @@ For a column of the NUMERIC type, you need to specify the precision and scale\. 
     {
         "ColumnName": "HourlyRate",
         "ColumnType": "NUMERIC",
-        "ColumnPrecision": "5"
+        "ColumnPrecision": "5",
         "ColumnScale": "2"
     }
 ...


### PR DESCRIPTION
*Issue #, if available:*
Missing comma makes example not working when copy & paste.
*Description of changes:*
Adding comma to the example.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
