### PR TITLE
Delete whitespace that causes malformed JSON

### DIFF
--- a/doc_source/CHAP_Security.APIRole.md
+++ b/doc_source/CHAP_Security.APIRole.md
@@ -142,7 +142,7 @@ If you use Amazon Redshift as your target database, you must create the IAM role
 1. Create a JSON file with the IAM policy following\. Name the JSON file `dmsAssumeRolePolicyDocument3.json`\. 
 
    ```
-    {
+   {
      "Version": "2012-10-17",
      "Statement": [
        {


### PR DESCRIPTION
Copying everything in this code block leads to malformed JSON due to a single space character at the start.

*Description of changes:*
Remove single space that leads to malformed JSON file when copying and pasting example.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
