### PR TITLE
Adding changes on GRANT SELECT vs GRANT READ

### DIFF
--- a/doc_source/CHAP_Source.Oracle.md
+++ b/doc_source/CHAP_Source.Oracle.md
@@ -217,6 +217,8 @@ An Amazon\-managed database is a database that is on an Amazon service such as A
 
 To grant privileges on Oracle databases on Amazon RDS, use the stored procedure `rdsadmin.rdsadmin_util.grant_sys_object`\. For more information, see [Granting SELECT or EXECUTE privileges to SYS Objects](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.Oracle.CommonDBATasks.html#Appendix.Oracle.CommonDBATasks.TransferPrivileges)\.
 
+In Oracle 12c granting permissions were modified for security purposes. As a result, GRANT SELECT for some objects does not work. If you encounter an ORA-01031: 'insufficient privileges' error while running any of the GRANT statements below, try GRANT READ instead. 
+
 Grant the following to the AWS DMS user account used to access the source Oracle endpoint\.
 +  `GRANT SELECT ANY TABLE to <dms_user>;`
 +  `GRANT SELECT on ALL_VIEWS to <dms_user>;`


### PR DESCRIPTION


*Issue #, if available:* 
Oracle 12c does not appear to support GRANT SELECT for some objects/permissions. I tried implementing the commands from this guide and encountered ORA-01031: insufficient privileges. I then used GRANT READ, which solved the permissions issue and I successfully got a test CDC job to run.

*Description of changes:*
I added a small sentence that provides a fix for the ORA-01031 issue. I was hesitant to change the actual commands from GRANT SELECT to GRANT READ. Let me know if you think that would be better, and I can change the GRANT SELECT clauses that do not work on newer versions of Oracle. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
