### PR TITLE
Update CHAP_Target.S3.md

### DIFF
--- a/doc_source/CHAP_Target.S3.md
+++ b/doc_source/CHAP_Target.S3.md
@@ -573,14 +573,14 @@ aws dms create-endpoint --endpoint-identifier s3-target-endpoint --engine-name s
 --s3-settings '{"ServiceAccessRoleArn": "your-service-access-ARN", "DataFormat": "parquet"}'
 ```
 
-Here, the `DataFormat` parameter is set to `parquet` to enable the format with all the S3 defaults\. These defaults include a dictionary encoding \(`"EncodingType: "rle-dictionary"`\) that uses a combination of bit\-packing and run\-length encoding to more efficiently store repeating values\.
+Here, the `DataFormat` parameter is set to `parquet` to enable the format with all the S3 defaults\. These defaults include a dictionary encoding \(`"EncodingType": "rle-dictionary"`\) that uses a combination of bit\-packing and run\-length encoding to more efficiently store repeating values\.
 
 You can add additional settings for options other than the defaults as in the following example\.
 
 ```
 aws dms create-endpoint --endpoint-identifier s3-target-endpoint --engine-name s3 --endpoint-type target
 --s3-settings '{"ServiceAccessRoleArn": "your-service-access-ARN", "BucketFolder": "your-bucket-folder",
-"BucketName": "your-bucket-name", "CompressionType": "GZIP", "DataFormat": "parquet", "EncodingType: "plain-dictionary", "dictPageSizeLimit": 3,072,000,
+"BucketName": "your-bucket-name", "CompressionType": "GZIP", "DataFormat": "parquet", "EncodingType": "plain-dictionary", "dictPageSizeLimit": 3,072,000,
 "EnableStatistics": false }'
 ```
 


### PR DESCRIPTION
*Issue #, if available:*
Missing double quotes results in broken json when pasting to AWS DMS json editor

*Description of changes:*
Adding missing double quotes on EncodingType json settings for DMS s3 target endpoint


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
