### PR TITLE
Adding missing comma on json example

### DIFF
--- a/doc_source/CHAP_Source.S3.md
+++ b/doc_source/CHAP_Source.S3.md
@@ -143,7 +143,7 @@ For a column of the NUMERIC type, specify the precision and scale\. *Precision* 
     {
         "ColumnName": "HourlyRate",
         "ColumnType": "NUMERIC",
-        "ColumnPrecision": "5"
+        "ColumnPrecision": "5",
         "ColumnScale": "2"
     }
 ...


### PR DESCRIPTION
*Description of changes:*

Adding missing comma in json example, if you copy this example a error would be thrown.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
